### PR TITLE
Fix py32 cpp support

### DIFF
--- a/PY32F002A/template/makefile
+++ b/PY32F002A/template/makefile
@@ -1,5 +1,3 @@
-# NOTE: For C++, set SYS_SUPPORT_CPP to 1 in system.h and rename main.c to main.cpp
-
 # ===================================================================================
 # Project Makefile
 # ===================================================================================
@@ -14,44 +12,43 @@
 #   pip install puyaisp
 #
 # Type "make flash" in the command line.
+#
+# For C++ see the commented CC and CFLAGS lines below
 # ===================================================================================
 
 # Files and Folders
 PROJECT  = template_app
 SOURCE   = src
 OUTPUT   = bin
+INCLUDE  = -I$(SOURCE)
 
 # Microcontroller Settings
 TARGET   = py32f002ax5
 F_CPU    = 24000000
 LDSCRIPT = ld/$(TARGET).ld
-CPUARCH  = -mcpu=cortex-m0plus #-mthumb
+CPUARCH  = -mcpu=cortex-m0plus -mthumb
 
 # Toolchain
 PREFIX   = arm-none-eabi
 CC       = $(PREFIX)-gcc
-CXX      = $(PREFIX)-g++
+# CC       = $(PREFIX)-g++
 OBJCOPY  = $(PREFIX)-objcopy
 OBJDUMP  = $(PREFIX)-objdump
-#ISPTOOL  = puyaisp -f $(OUTPUT)/$(PROJECT).bin
-ISPTOOL  = pyocd load $(OUTPUT)/$(PROJECT).bin -t $(TARGET)
-CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
+OBJSIZE  = $(PREFIX)-size
+ISPTOOL  = puyaisp -f $(OUTPUT)/$(PROJECT).bin
+# ISPTOOL  = pyocd load $(OUTPUT)/$(PROJECT).bin -t $(TARGET)
+
+# NOTE: do not use -flto and -nostartfiles together for C++ project
+# should be fine for C projects tho, saves about 100 bytes of flash
 
 # Compiler Flags
-FLAGS    = -Os -flto -Wall -I$(SOURCE) $(CPUARCH) -DF_CPU=$(F_CPU) -fdata-sections -ffunction-sections -fno-builtin -fno-common
-CFLAGS   = $(FLAGS) -std=gnu23
-CPPFLAGS = $(FLAGS) -std=gnu++26 -fno-exceptions -fno-rtti -Wno-register -Wno-volatile
-LDFLAGS  = -Wl,--gc-sections,--build-id=none,--no-warn-rwx-segments,--print-memory-usage
-LDFLAGS += -T$(LDSCRIPT) --specs=nano.specs --specs=nosys.specs -nostartfiles #-nostdlib
-
-ASM_SRCS := $(wildcard $(SOURCE)/*.S)  	$(wildcard $(SOURCE)/*/*.S)
-C_SRCS   := $(wildcard $(SOURCE)/*.c) 	$(wildcard $(SOURCE)/*/*.c)
-CPP_SRCS := $(wildcard $(SOURCE)/*.cpp) $(wildcard $(SOURCE)/*/*.cpp)
-
-ASM_OBJS := $(patsubst $(SOURCE)/%.S,   $(OUTPUT)/obj/%.o, $(ASM_SRCS))
-C_OBJS   := $(patsubst $(SOURCE)/%.c,   $(OUTPUT)/obj/%.o, $(C_SRCS))
-CPP_OBJS := $(patsubst $(SOURCE)/%.cpp, $(OUTPUT)/obj/%.o, $(CPP_SRCS))
-OBJS     := $(ASM_OBJS) $(C_OBJS) $(CPP_OBJS)
+CFLAGS   = -Os -flto -std=gnu23 -Wall
+# CFLAGS   = -Os -flto -std=c++26 -fno-exceptions -fno-rtti -Wall -Wno-volatile -Wno-register -fpermissive
+CFLAGS  += $(INCLUDE) $(CPUARCH) -DF_CPU=$(F_CPU) -fdata-sections -ffunction-sections -fno-builtin -fno-common
+LDFLAGS  = -T$(LDSCRIPT) --specs=nano.specs --specs=nosys.specs #-nostartfiles #-nostdlib
+LDFLAGS += -Wl,--gc-sections,--build-id=none,--no-warn-rwx-segments,--print-memory-usage
+CFILES   = $(wildcard $(SOURCE)/*.c) $(wildcard $(SOURCE)/*.cpp) $(wildcard $(SOURCE)/*.S)
+CFILES  += $(wildcard $(SOURCE)/*/*.c) $(wildcard $(SOURCE)/*/*.cpp) $(wildcard $(SOURCE)/*/*.S)
 
 # Symbolic Targets
 help:
@@ -63,22 +60,10 @@ help:
 	@echo "make flash     compile and upload to MCU"
 	@echo "make clean     remove all build files"
 
-$(OUTPUT)/obj/%.o: $(SOURCE)/%.S
-	@mkdir -p $(@D)
-	@$(CC) -o $@ -c $< $(CFLAGS)
-
-$(OUTPUT)/obj/%.o: $(SOURCE)/%.c
-	@mkdir -p $(@D)
-	@$(CC) -o $@ -c $< $(CFLAGS)
-
-$(OUTPUT)/obj/%.o: $(SOURCE)/%.cpp
-	@mkdir -p $(@D)
-	@$(CXX) -o $@ -c $< $(CPPFLAGS)
-
-$(OUTPUT)/$(PROJECT).elf: $(OBJS)
+$(OUTPUT)/$(PROJECT).elf: $(CFILES)
 	@echo "Building $(OUTPUT)/$(PROJECT).elf ..."
-	@mkdir -p $(@D)
-	@$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+	@mkdir -p $(OUTPUT)
+	@$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
 $(OUTPUT)/$(PROJECT).lst: $(OUTPUT)/$(PROJECT).elf
 	@echo "Building $(OUTPUT)/$(PROJECT).lst ..."
@@ -100,15 +85,15 @@ $(OUTPUT)/$(PROJECT).asm: $(OUTPUT)/$(PROJECT).elf
 	@echo "Disassembling to $(OUTPUT)/$(PROJECT).asm ..."
 	@$(OBJDUMP) -d $(OUTPUT)/$(PROJECT).elf > $(OUTPUT)/$(PROJECT).asm
 
-all:	$(OUTPUT)/$(PROJECT).lst $(OUTPUT)/$(PROJECT).map $(OUTPUT)/$(PROJECT).bin $(OUTPUT)/$(PROJECT).hex $(OUTPUT)/$(PROJECT).asm
+all:	$(OUTPUT)/$(PROJECT).lst $(OUTPUT)/$(PROJECT).map $(OUTPUT)/$(PROJECT).bin $(OUTPUT)/$(PROJECT).hex $(OUTPUT)/$(PROJECT).asm size
 
-elf:	$(OUTPUT)/$(PROJECT).elf removetemp
+elf:	$(OUTPUT)/$(PROJECT).elf
 
-bin:	$(OUTPUT)/$(PROJECT).bin removetemp removeelf
+bin:	$(OUTPUT)/$(PROJECT).bin removeelf
 
-hex:	$(OUTPUT)/$(PROJECT).hex removetemp removeelf
+hex:	$(OUTPUT)/$(PROJECT).hex removeelf
 
-asm:	$(OUTPUT)/$(PROJECT).asm removetemp removeelf
+asm:	$(OUTPUT)/$(PROJECT).asm removeelf
 
 flash:	$(OUTPUT)/$(PROJECT).bin removeelf
 	@echo "Uploading to MCU ..."
@@ -116,12 +101,7 @@ flash:	$(OUTPUT)/$(PROJECT).bin removeelf
 
 clean:
 	@echo "Cleaning all up ..."
-	@$(CLEAN)
-	@rm -rf $(OUTPUT)
-
-removetemp:
-	@echo "Removing temporary files ..."
-	@$(CLEAN)
+	@rm -r $(OUTPUT)
 
 removeelf:
 	@echo "Removing $(OUTPUT)/$(PROJECT).elf ..."

--- a/PY32F002A/template/src/system.c
+++ b/PY32F002A/template/src/system.c
@@ -278,7 +278,7 @@ void BOOT_now(void) {
 // ===================================================================================
 // C++ Support
 // ===================================================================================
-#if SYS_SUPPORT_CPP == 1
+#ifdef __cplusplus
 extern void __cxa_pure_virtual() { while (1); }
 extern void (*__preinit_array_start[]) (void) __attribute__((weak));
 extern void (*__preinit_array_end[]) (void) __attribute__((weak));
@@ -297,12 +297,16 @@ void __libc_init_array(void) {
 // ===================================================================================
 // C version of PY32F030 Startup .s file
 // ===================================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern uint32_t _sbss, _ebss, _sdata, _edata, _sidata;
 extern void _estack(void);
 
 // Prototypes
 int main(void)                __attribute__((section(".text.main"), used));
-void (*const vectors[])(void) __attribute__((section(".isr_vector"), used));
 void Reset_Handler(void)      __attribute__((section(".text.irq_handler"), naked, used, noreturn));
 
 #if SYS_USE_VECTORS > 0
@@ -311,7 +315,7 @@ void Default_Handler(void)    __attribute__((section(".text.irq_handler"), naked
 void Default_Handler(void)    { while(1); }
 
 // All interrupt handlers are aliased to default_handler unless overridden individually
-#define DUMMY_HANDLER __attribute__((section(".text.irq_handler"), weak, alias("Default_Handler"), used))
+#define DUMMY_HANDLER __attribute__((section(".text.irq_handler"), weak, alias("Default_Handler"), used, nothrow))
 DUMMY_HANDLER void NMI_Handler(void);
 DUMMY_HANDLER void HardFault_Handler(void);
 DUMMY_HANDLER void SVC_Handler(void);
@@ -352,7 +356,7 @@ DUMMY_HANDLER void USB_IRQHandler(void);
 #endif  // SYS_USE_VECTORS > 0
 
 // Interrupt vector table
-void (*const vectors[])(void) = {
+void (*const vectors[])(void) __attribute__((section(".isr_vector"), used)) = {
   &_estack,                       //  0 - Initial Stack Pointer Value
 
   // Cortex-M0+ handlers
@@ -438,7 +442,7 @@ void Reset_Handler(void) {
   SYS_init();
 
   // C++ Support
-  #if SYS_SUPPORT_CPP == 1
+  #ifdef __cplusplus
   __libc_init_array();
   #endif
 
@@ -446,3 +450,7 @@ void Reset_Handler(void) {
   main();
   while(1);
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/PY32F002A/template/src/system.h
+++ b/PY32F002A/template/src/system.h
@@ -142,7 +142,6 @@ extern "C" {
 #define SYS_GPIO_EN       1         // 1: enable GPIO ports on startup
 #define SYS_CLEAR_BSS     1         // 1: clear uninitialized variables
 #define SYS_USE_VECTORS   1         // 1: create interrupt vector table
-#define SYS_SUPPORT_CPP   0         // 1: enable c++ static object initialisation
 #define SYS_USE_HSE       0         // 1: use external crystal for system clock
 
 // ===================================================================================


### PR DESCRIPTION
After using using #11 for slightly larger project, i started facing issues. So i did some testing on the pros and cons of 2 step vs 1 step compilation:

### 2 step compilation: (current)
<table><thead>
  <tr>
    <th rowspan="2"></th>
    <th colspan="4">your startfiles</th>
    <th colspan="4">gcc startfiles</th>
  </tr>
  <tr>
    <th>-Os</th>
    <th>-O3</th>
    <th>-Os -flto</th>
    <th>-O3 -flto</th>
    <th>-Os</th>
    <th>-O3</th>
    <th>-Os -flto</th>
    <th>-O3 -flto</th>
  </tr></thead>
<tbody>
  <tr>
    <td>compiles?</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌¹</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
  </tr>
  <tr>
    <td>static ctor()</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌²</td>
    <td>NA</td>
    <td>❌</td>
    <td>❌</td>
    <td>❌</td>
    <td>❌</td>
  </tr>
  <tr>
    <td>malloc()</td>
    <td>❌</td>
    <td>❌</td>
    <td>❌</td>
    <td>NA</td>
    <td>❌</td>
    <td>❌</td>
    <td>❌</td>
    <td>❌</td>
  </tr>
  <tr>
    <td>local ctor()</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌²</td>
    <td>NA</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
  </tr>
</tbody>
</table>

### 1 step compilation (this PR):
<table><thead>
  <tr>
    <th rowspan="2"></th>
    <th colspan="4">your startfiles</th>
    <th colspan="4">gcc startfiles</th>
  </tr>
  <tr>
    <th>-Os</th>
    <th>-O3</th>
    <th>-Os -flto</th>
    <th>-O3 -flto</th>
    <th>-Os</th>
    <th>-O3</th>
    <th>-Os -flto</th>
    <th>-O3 -flto</th>
  </tr></thead>
<tbody>
  <tr>
    <td>compiles?</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌¹</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
  </tr>
  <tr>
    <td>static ctor()</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌²</td>
    <td>NA</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
  </tr>
  <tr>
    <td>malloc()</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>NA</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
  </tr>
  <tr>
    <td>local ctor()</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌²</td>
    <td>NA</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
    <td>✅</td>
  </tr>
</tbody>
</table>

#### Footnotes:
**¹ :** `/tmp/ccARG1q6.s:542: Error: invalid offset, value too big (0x00000828)`, error doesn't happen on small programs.
**² :** idk wtf is happening here. works fine for some classes, freezes on ctor call for some, freezes on ctor return for some.

### Conclusion:
Even though the 1 step compilation approach is not the "correct/clean way" of doing things as we are treating everything as c++ code, it is clear that it is the only way that works properly. This makefile defaults to `-Os -flto` with gcc startfiles as the safe options.